### PR TITLE
MapClassLoaderResourceProvider.toString removed map.toString

### DIFF
--- a/src/main/java/walkingkooka/classloader/MapClassLoaderResourceProvider.java
+++ b/src/main/java/walkingkooka/classloader/MapClassLoaderResourceProvider.java
@@ -48,9 +48,4 @@ final class MapClassLoaderResourceProvider implements ClassLoaderResourceProvide
     }
 
     private final Map<ClassLoaderResourcePath, ClassLoaderResource> pathToResource;
-
-    @Override
-    public String toString() {
-        return this.pathToResource.toString();
-    }
 }


### PR DESCRIPTION
- Too verbose, restored original default Object.toString